### PR TITLE
feat: Complete core model seeders + bugfixes in auth and seeders

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,21 @@
             <artifactId>jakarta.validation-api</artifactId>
             <version>3.1.0</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <version>3.2.5</version> <!-- Match your Spring Boot version -->
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>

--- a/src/main/java/com/henry/universitycourseschedular/data/CollegeBuildingSeeder.java
+++ b/src/main/java/com/henry/universitycourseschedular/data/CollegeBuildingSeeder.java
@@ -1,0 +1,29 @@
+package com.henry.universitycourseschedular.data;
+
+import com.henry.universitycourseschedular.models.core.CollegeBuilding;
+import com.henry.universitycourseschedular.repositories.CollegeBuildingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class CollegeBuildingSeeder {
+
+    private final CollegeBuildingRepository collegeBuildingRepository;
+
+    public void seed() {
+        if (collegeBuildingRepository.count() > 0) return;
+
+        collegeBuildingRepository.saveAll(List.of(
+                CollegeBuilding.builder().code("CST").name("College of Science & Technology").build(),
+                CollegeBuilding.builder().code("CMSS").name("College of Management & Social Sciences").build(),
+                CollegeBuilding.builder().code("CEDS").name("College of Entrepreneurial Development Studies").build(),
+                CollegeBuilding.builder().code("PETE").name("College of Petroleum & Petrochemical Engineering").build(),
+                CollegeBuilding.builder().code("MECH").name("College of Mechanical Engineering").build(),
+                CollegeBuilding.builder().code("CIVIL").name("College of Civil Engineering").build(),
+                CollegeBuilding.builder().code("EIE").name("College of Electrical Engineering").build()
+        ));
+    }
+}

--- a/src/main/java/com/henry/universitycourseschedular/data/DepartmentSeeder.java
+++ b/src/main/java/com/henry/universitycourseschedular/data/DepartmentSeeder.java
@@ -33,42 +33,42 @@ public class DepartmentSeeder {
 
         // CST Departments
         all.addAll(List.of(
-                new Department(null, "ARCH", "Architecture",                       cst),
-                new Department(null, "BT",   "Building Technology",               cst),
-                new Department(null, "EM",   "Estate Management",                 cst),
-                new Department(null, "BIS",  "Biological Sciences",               cst),
-                new Department(null, "BCH",  "Biochemistry",                      cst),
-                new Department(null, "CHEM", "Chemistry",                         cst),
-                new Department(null, "CIS",  "Computer & Information Sciences",   cst),
-                new Department(null, "MATH", "Mathematics",                       cst),
-                new Department(null, "PHYS", "Physics",                           cst)
+                new Department(null, "Architecture",                    "ARCH", cst),
+                new Department(null, "Building Technology",             "BT",   cst),
+                new Department(null, "Estate Management",               "EM",   cst),
+                new Department(null, "Biological Sciences",             "BIS",  cst),
+                new Department(null, "Biochemistry",                    "BCH",  cst),
+                new Department(null, "Chemistry",                       "CHEM", cst),
+                new Department(null, "Computer & Information Sciences", "CIS",  cst),
+                new Department(null, "Mathematics",                     "MATH", cst),
+                new Department(null, "Physics",                         "PHYS", cst)
         ));
 
         // CMSS Departments
         all.addAll(List.of(
-                new Department(null, "ACCT", "Accounting",                cmss),
-                new Department(null, "BF",   "Banking & Finance",         cmss),
-                new Department(null, "BM",   "Business Management",       cmss),
-                new Department(null, "ECON", "Economics",                 cmss),
-                new Department(null, "MCOM", "Mass Communication",        cmss),
-                new Department(null, "SOC",  "Sociology",                 cmss)
+                new Department(null, "Accounting",              "ACCT", cmss),
+                new Department(null, "Banking & Finance",       "BF",   cmss),
+                new Department(null, "Business Management",     "BM",   cmss),
+                new Department(null, "Economics",               "ECON", cmss),
+                new Department(null, "Mass Communication",      "MCOM", cmss),
+                new Department(null, "Sociology",               "SOC",  cmss)
         ));
 
         // Leadership & Development Studies (under CEDS)
         all.addAll(List.of(
-                new Department(null, "PSIR", "Political Science & IR",    lds),
-                new Department(null, "PSY",  "Psychology",                lds),
-                new Department(null, "LGS",  "Languages & General Studies", lds),
-                new Department(null, "LS",   "Leadership Studies",        lds)
+                new Department(null, "Political Science & IR",         "PSIR", lds),
+                new Department(null, "Psychology",                     "PSY",  lds),
+                new Department(null, "Languages & General Studies",    "LGS",  lds),
+                new Department(null, "Leadership Studies",             "LS",   lds)
         ));
 
         // Colleges of Engineering (each under their own building)
         all.addAll(List.of(
-                new Department(null, "CIVIL",    "Civil Engineering",      coe3),
-                new Department(null, "EIE",      "Electrical & Info Eng.", coe4),
-                new Department(null, "MECH",     "Mechanical Engineering", coe2),
-                new Department(null, "PETE",     "Petroleum Engineering",  coe1),
-                new Department(null, "CHEMENG",  "Chemical Engineering",   coe1)  // or its own building
+                new Department(null, "Civil Engineering",              "CIVIL",    coe3),
+                new Department(null, "Electrical & Info Eng.",         "EIE",      coe4),
+                new Department(null, "Mechanical Engineering",         "MECH",     coe2),
+                new Department(null, "Petroleum Engineering",          "PETE",     coe1),
+                new Department(null, "Chemical Engineering",           "CHEMENG",  coe1)
         ));
 
         departmentRepository.saveAll(all);

--- a/src/main/java/com/henry/universitycourseschedular/data/DepartmentSeeder.java
+++ b/src/main/java/com/henry/universitycourseschedular/data/DepartmentSeeder.java
@@ -1,0 +1,82 @@
+package com.henry.universitycourseschedular.data;
+
+import com.henry.universitycourseschedular.exceptions.ResourceNotFoundException;
+import com.henry.universitycourseschedular.models.core.CollegeBuilding;
+import com.henry.universitycourseschedular.models.core.Department;
+import com.henry.universitycourseschedular.repositories.CollegeBuildingRepository;
+import com.henry.universitycourseschedular.repositories.DepartmentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class DepartmentSeeder {
+
+    private final DepartmentRepository departmentRepository;
+    private final CollegeBuildingRepository buildingRepository;
+
+    public void seed() {
+        if (departmentRepository.count() > 0) return;
+
+        CollegeBuilding cst  = getBuilding("CST");
+        CollegeBuilding cmss = getBuilding("CMSS");
+        CollegeBuilding lds  = getBuilding("CEDS"); // Leadership & Dev Studies under CEDS
+        CollegeBuilding coe1 = getBuilding("PETE");
+        CollegeBuilding coe2 = getBuilding("MECH");
+        CollegeBuilding coe3 = getBuilding("CIVIL");
+        CollegeBuilding coe4 = getBuilding("EIE");
+
+        List<Department> all = new ArrayList<>();
+
+        // CST Departments
+        all.addAll(List.of(
+                new Department(null, "ARCH", "Architecture",                       cst),
+                new Department(null, "BT",   "Building Technology",               cst),
+                new Department(null, "EM",   "Estate Management",                 cst),
+                new Department(null, "BIS",  "Biological Sciences",               cst),
+                new Department(null, "BCH",  "Biochemistry",                      cst),
+                new Department(null, "CHEM", "Chemistry",                         cst),
+                new Department(null, "CIS",  "Computer & Information Sciences",   cst),
+                new Department(null, "MATH", "Mathematics",                       cst),
+                new Department(null, "PHYS", "Physics",                           cst)
+        ));
+
+        // CMSS Departments
+        all.addAll(List.of(
+                new Department(null, "ACCT", "Accounting",                cmss),
+                new Department(null, "BF",   "Banking & Finance",         cmss),
+                new Department(null, "BM",   "Business Management",       cmss),
+                new Department(null, "ECON", "Economics",                 cmss),
+                new Department(null, "MCOM", "Mass Communication",        cmss),
+                new Department(null, "SOC",  "Sociology",                 cmss)
+        ));
+
+        // Leadership & Development Studies (under CEDS)
+        all.addAll(List.of(
+                new Department(null, "PSIR", "Political Science & IR",    lds),
+                new Department(null, "PSY",  "Psychology",                lds),
+                new Department(null, "LGS",  "Languages & General Studies", lds),
+                new Department(null, "LS",   "Leadership Studies",        lds)
+        ));
+
+        // Colleges of Engineering (each under their own building)
+        all.addAll(List.of(
+                new Department(null, "CIVIL",    "Civil Engineering",      coe3),
+                new Department(null, "EIE",      "Electrical & Info Eng.", coe4),
+                new Department(null, "MECH",     "Mechanical Engineering", coe2),
+                new Department(null, "PETE",     "Petroleum Engineering",  coe1),
+                new Department(null, "CHEMENG",  "Chemical Engineering",   coe1)  // or its own building
+        ));
+
+        departmentRepository.saveAll(all);
+    }
+
+    private CollegeBuilding getBuilding(String code) {
+        return buildingRepository.findByCode(code)
+                .orElseThrow(() -> new ResourceNotFoundException("Building not found: " + code));
+    }
+
+}

--- a/src/main/java/com/henry/universitycourseschedular/data/ProgramSeeder.java
+++ b/src/main/java/com/henry/universitycourseschedular/data/ProgramSeeder.java
@@ -1,0 +1,74 @@
+package com.henry.universitycourseschedular.data;
+
+import com.henry.universitycourseschedular.exceptions.ResourceNotFoundException;
+import com.henry.universitycourseschedular.models.core.Department;
+import com.henry.universitycourseschedular.models.core.Program;
+import com.henry.universitycourseschedular.repositories.DepartmentRepository;
+import com.henry.universitycourseschedular.repositories.ProgramRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.function.Function;
+
+@Component
+@RequiredArgsConstructor
+public class ProgramSeeder {
+
+    private final ProgramRepository programRepository;
+    private final DepartmentRepository departmentRepository;
+
+    public void seed() {
+        if (programRepository.count() > 0) return;
+
+        Function<String, Department> getDept = code ->
+                departmentRepository.findByCode(code)
+                        .orElseThrow(() -> new ResourceNotFoundException("Dept not found: " + code));
+
+        programRepository.saveAll(List.of(
+                // CST Programs
+                Program.builder().code("ARCH").name("Architecture").department(getDept.apply("ARCH")).build(),
+                Program.builder().code("BT").name("Building Technology").department(getDept.apply("BT")).build(),
+                Program.builder().code("EM").name("Estate Management").department(getDept.apply("EM")).build(),
+                Program.builder().code("ABT").name("Applied Biology & Biotechnology").department(getDept.apply("BIS")).build(),
+                Program.builder().code("MICR").name("Microbiology").department(getDept.apply("BIS")).build(),
+                Program.builder().code("BIOCHEM").name("Biochemistry").department(getDept.apply("BCH")).build(),
+                Program.builder().code("MBIO").name("Molecular Biology").department(getDept.apply("BCH")).build(),
+                Program.builder().code("ICHEM").name("Industrial Chemistry").department(getDept.apply("CHEM")).build(),
+                Program.builder().code("CS").name("Computer Science").department(getDept.apply("CIS")).build(),
+                Program.builder().code("MIS").name("Management Info Systems").department(getDept.apply("CIS")).build(),
+                Program.builder().code("IMATH").name("Industrial Mathematics").department(getDept.apply("MATH")).build(),
+                Program.builder().code("IPHY").name("Industrial Physics").department(getDept.apply("PHYS")).build(),
+
+                // CMSS Programs
+                Program.builder().code("ACCT").name("Accounting").department(getDept.apply("ACCT")).build(),
+                Program.builder().code("BF").name("Banking & Finance").department(getDept.apply("BF")).build(),
+                Program.builder().code("BBA").name("Business Administration").department(getDept.apply("BM")).build(),
+                Program.builder().code("IRHR").name("Ind. Relations & HRM").department(getDept.apply("BM")).build(),
+                Program.builder().code("MKT").name("Marketing & Entrepreneurship").department(getDept.apply("BM")).build(),
+                Program.builder().code("ECON").name("Economics").department(getDept.apply("ECON")).build(),
+                Program.builder().code("DSS").name("Demography & Social Stats").department(getDept.apply("ECON")).build(),
+                Program.builder().code("MCOM").name("Mass Communication").department(getDept.apply("MCOM")).build(),
+                Program.builder().code("SOC").name("Sociology").department(getDept.apply("SOC")).build(),
+
+                // LDS Programs
+                Program.builder().code("IR").name("International Relations").department(getDept.apply("PSIR")).build(),
+                Program.builder().code("PSS").name("Policy & Strategic Studies").department(getDept.apply("PSIR")).build(),
+                Program.builder().code("PS").name("Political Science").department(getDept.apply("PSIR")).build(),
+                Program.builder().code("ENG").name("English").department(getDept.apply("LGS")).build(),
+                Program.builder().code("FRE").name("French").department(getDept.apply("LGS")).build(),
+                Program.builder().code("PSY").name("Psychology").department(getDept.apply("PSY")).build(),
+                Program.builder().code("CERTLEAD").name("Leadership Certificate").department(getDept.apply("LS")).build(),
+                Program.builder().code("DIPLEAD").name("Leadership Diploma").department(getDept.apply("LS")).build(),
+
+                // CoE Programs
+                Program.builder().code("CIVIL").name("Civil Engineering").department(getDept.apply("CIVIL")).build(),
+                Program.builder().code("CE").name("Computer Engineering").department(getDept.apply("EIE")).build(),
+                Program.builder().code("EEE").name("Electrical & Electronics Eng.").department(getDept.apply("EIE")).build(),
+                Program.builder().code("ICE").name("Inf. & Comm. Eng.").department(getDept.apply("EIE")).build(),
+                Program.builder().code("MECH").name("Mechanical Engineering").department(getDept.apply("MECH")).build(),
+                Program.builder().code("PETE").name("Petroleum Engineering").department(getDept.apply("PETE")).build(),
+                Program.builder().code("CHEMENG").name("Chemical Engineering").department(getDept.apply("CHEMENG")).build()
+        ));
+    }
+}

--- a/src/main/java/com/henry/universitycourseschedular/data/TimeSlotSeeder.java
+++ b/src/main/java/com/henry/universitycourseschedular/data/TimeSlotSeeder.java
@@ -1,0 +1,55 @@
+package com.henry.universitycourseschedular.data;
+
+import com.henry.universitycourseschedular.models.schedule.TimeSlot;
+import com.henry.universitycourseschedular.repositories.TimeSlotRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class TimeSlotSeeder {
+
+    private final TimeSlotRepository timeSlotRepository;
+
+    @PostConstruct
+    public void seed() {
+        if (timeSlotRepository.count() > 0) return; // Prevent re-seeding
+
+        List<TimeSlot> timeSlots = new ArrayList<>();
+
+        // Define a fixed set of time intervals (e.g., 1-hour slots)
+        LocalTime[] starts = {
+                LocalTime.of(8, 0),
+                LocalTime.of(9, 0),
+                LocalTime.of(10, 0),
+                LocalTime.of(11, 0),
+                LocalTime.of(12, 0),
+                LocalTime.of(13, 0),
+                LocalTime.of(14, 0),
+                LocalTime.of(15, 0),
+                LocalTime.of(16, 0),
+                LocalTime.of(17, 0),
+                LocalTime.of(18, 0),
+                LocalTime.of(19, 0)
+        };
+
+        for (DayOfWeek day : DayOfWeek.values()) {
+            if (day == DayOfWeek.SATURDAY || day == DayOfWeek.SUNDAY) continue; // skip weekends
+
+            for (LocalTime start : starts) {
+                timeSlots.add(TimeSlot.builder()
+                        .startTime(start)
+                        .endTime(start.plusHours(1))
+                        .dayOfWeek(day)
+                        .build());
+            }
+        }
+        timeSlotRepository.saveAll(timeSlots);
+    }
+}

--- a/src/main/java/com/henry/universitycourseschedular/data/VenueSeeder.java
+++ b/src/main/java/com/henry/universitycourseschedular/data/VenueSeeder.java
@@ -80,8 +80,11 @@ public class VenueSeeder {
         List<Venue> venues = dtos.stream()
                 .filter(Objects::nonNull)
                 .map(dto -> {
-                    CollegeBuilding cb = buildingRepository.findByCode(dto.getCollegeCode())
-                            .orElseThrow(() -> new ResourceNotFoundException("Building not found: " + dto.getCollegeCode()));
+                    CollegeBuilding cb = null;
+                    if (dto.getCollegeCode() != null) {
+                        cb = buildingRepository.findByCode(dto.getCollegeCode())
+                                .orElseThrow(() -> new ResourceNotFoundException("Building not found: " + dto.getCollegeCode()));
+                    }
                     return VenueMapper.toEntity(dto, cb);
                 })
                 .toList();

--- a/src/main/java/com/henry/universitycourseschedular/data/VenueSeeder.java
+++ b/src/main/java/com/henry/universitycourseschedular/data/VenueSeeder.java
@@ -1,0 +1,91 @@
+package com.henry.universitycourseschedular.data;
+
+import com.henry.universitycourseschedular.exceptions.ResourceNotFoundException;
+import com.henry.universitycourseschedular.mapper.VenueMapper;
+import com.henry.universitycourseschedular.models._dto.VenueDTO;
+import com.henry.universitycourseschedular.models.core.CollegeBuilding;
+import com.henry.universitycourseschedular.models.core.Venue;
+import com.henry.universitycourseschedular.repositories.CollegeBuildingRepository;
+import com.henry.universitycourseschedular.repositories.VenueRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Objects;
+
+@Component
+@RequiredArgsConstructor
+public class VenueSeeder {
+
+    private final VenueRepository venueRepository;
+    private final CollegeBuildingRepository buildingRepository;
+
+    public void seed() {
+        if (venueRepository.count() > 0) return;
+
+        List<VenueDTO> dtos = List.of(
+                // CMSS
+                VenueDTO.builder().name("CMSS E101").capacity(192).collegeCode("CMSS").build(),
+                VenueDTO.builder().name("CMSS A201").capacity(76).collegeCode("CMSS").build(),
+                VenueDTO.builder().name("CMSS E201").capacity(69).collegeCode("CMSS").build(),
+                VenueDTO.builder().name("CMSS G201").capacity(144).collegeCode("CMSS").build(),
+                VenueDTO.builder().name("CMSS G301").capacity(100).collegeCode("CMSS").build(),
+                VenueDTO.builder().name("CMSS B301").capacity(144).collegeCode("CMSS").build(),
+                VenueDTO.builder().name("CMSS C301").capacity(488).collegeCode("CMSS").build(),
+                VenueDTO.builder().name("CMSS E301").capacity(92).collegeCode("CMSS").build(),
+                VenueDTO.builder().name("CMSS H301").capacity(132).collegeCode("CMSS").build(),
+                VenueDTO.builder().name("CMSS E401A").capacity(36).collegeCode("CMSS").build(),
+                VenueDTO.builder().name("CMSS E401B").capacity(0).collegeCode("CMSS").available(false).build(), // unavailable
+                VenueDTO.builder().name("CMSS F301").capacity(92).collegeCode("CMSS").build(),
+                VenueDTO.builder().name("CMSS F401").capacity(60).collegeCode("CMSS").build(),
+                VenueDTO.builder().name("CMSS C401").capacity(128).collegeCode("CMSS").build(),
+                VenueDTO.builder().name("CMSS H401").capacity(448).collegeCode("CMSS").build(),
+
+                // CST
+                VenueDTO.builder().name("CST H111 Lab").capacity(300).collegeCode("CST").build(),
+                VenueDTO.builder().name("CST H112").capacity(150).collegeCode("CST").build(),
+                VenueDTO.builder().name("CST H108").capacity(81).collegeCode("CST").build(),
+                VenueDTO.builder().name("CST H107").capacity(243).collegeCode("CST").build(),
+                VenueDTO.builder().name("CST Hall 204").capacity(120).collegeCode("CST").build(),
+                VenueDTO.builder().name("CST Hall 203").capacity(120).collegeCode("CST").build(),
+                VenueDTO.builder().name("CST Hall 202").capacity(110).collegeCode("CST").build(),
+                VenueDTO.builder().name("CST Hall 201").capacity(160).collegeCode("CST").build(),
+                VenueDTO.builder().name("CST Seminar Room (500L Only)").capacity(80).collegeCode("CST").build(),
+                VenueDTO.builder().name("CST Estate Lab").capacity(57).collegeCode("CST").build(),
+                VenueDTO.builder().name("CST Microbiology Lab").capacity(120).collegeCode("CST").build(),
+                VenueDTO.builder().name("CST Biology Lab").capacity(270).collegeCode("CST").build(),
+                VenueDTO.builder().name("CST Comp Lab 1").capacity(60).collegeCode("CST").build(),
+                VenueDTO.builder().name("CST Comp Lab 2").capacity(144).collegeCode("CST").build(),
+                VenueDTO.builder().name("CST H302").capacity(330).collegeCode("CST").build(),
+                VenueDTO.builder().name("CST Biochem Lab 1").capacity(100).collegeCode("CST").build(),
+                VenueDTO.builder().name("CST Biochem Lab 2").capacity(100).collegeCode("CST").build(),
+                VenueDTO.builder().name("CST H308").capacity(129).collegeCode("CST").build(),
+                VenueDTO.builder().name("CST H307").capacity(117).collegeCode("CST").build(),
+                VenueDTO.builder().name("CST H306").capacity(120).collegeCode("CST").build(),
+                VenueDTO.builder().name("CST MSc Studio 1").capacity(40).collegeCode("CST").build(),
+                VenueDTO.builder().name("CST MSc Studio 2").capacity(40).collegeCode("CST").build(),
+                VenueDTO.builder().name("CST Digital Design Studio").capacity(60).collegeCode("CST").build(),
+                VenueDTO.builder().name("CST Studio 100").capacity(50).collegeCode("CST").build(),
+                VenueDTO.builder().name("CST Studio 200").capacity(50).collegeCode("CST").build(),
+                VenueDTO.builder().name("CST Studio 300").capacity(50).collegeCode("CST").build(),
+                VenueDTO.builder().name("CST Studio 400").capacity(50).collegeCode("CST").build(),
+
+                // General
+                VenueDTO.builder().name("Lecture Theatre 1").capacity(2100).build(),
+                VenueDTO.builder().name("Lecture Theatre 2").capacity(1100).build(),
+                VenueDTO.builder().name("University Chapel").capacity(2500).build()
+        );
+
+
+        List<Venue> venues = dtos.stream()
+                .filter(Objects::nonNull)
+                .map(dto -> {
+                    CollegeBuilding cb = buildingRepository.findByCode(dto.getCollegeCode())
+                            .orElseThrow(() -> new ResourceNotFoundException("Building not found: " + dto.getCollegeCode()));
+                    return VenueMapper.toEntity(dto, cb);
+                })
+                .toList();
+
+        venueRepository.saveAll(venues);
+    }
+}

--- a/src/main/java/com/henry/universitycourseschedular/data/_SeederRunner.java
+++ b/src/main/java/com/henry/universitycourseschedular/data/_SeederRunner.java
@@ -19,7 +19,7 @@ public class _SeederRunner {
         collegeBuildingSeeder.seed();
         departmentSeeder.seed();
         programSeeder.seed();
-//        venueSeeder.seed();
+        venueSeeder.seed();
         timeSlotSeeder.seed();
     }
 

--- a/src/main/java/com/henry/universitycourseschedular/data/_SeederRunner.java
+++ b/src/main/java/com/henry/universitycourseschedular/data/_SeederRunner.java
@@ -1,0 +1,26 @@
+package com.henry.universitycourseschedular.data;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class _SeederRunner {
+
+    private final CollegeBuildingSeeder collegeBuildingSeeder;
+    private final DepartmentSeeder departmentSeeder;
+    private final ProgramSeeder programSeeder;
+    private final VenueSeeder venueSeeder;
+    private final TimeSlotSeeder timeSlotSeeder;
+
+    @PostConstruct
+    public void run() {
+        collegeBuildingSeeder.seed();
+        departmentSeeder.seed();
+        programSeeder.seed();
+//        venueSeeder.seed();
+        timeSlotSeeder.seed();
+    }
+
+}

--- a/src/main/java/com/henry/universitycourseschedular/mapper/VenueMapper.java
+++ b/src/main/java/com/henry/universitycourseschedular/mapper/VenueMapper.java
@@ -1,0 +1,16 @@
+package com.henry.universitycourseschedular.mapper;
+
+import com.henry.universitycourseschedular.models._dto.VenueDTO;
+import com.henry.universitycourseschedular.models.core.CollegeBuilding;
+import com.henry.universitycourseschedular.models.core.Venue;
+
+public class VenueMapper {
+
+    public static Venue toEntity(VenueDTO dto, CollegeBuilding building) {
+        return Venue.builder()
+                .name(dto.getName())
+                .capacity(dto.getCapacity())
+                .collegeBuilding(building)
+                .build();
+    }
+}

--- a/src/main/java/com/henry/universitycourseschedular/models/_dto/OnboardUserDto.java
+++ b/src/main/java/com/henry/universitycourseschedular/models/_dto/OnboardUserDto.java
@@ -22,10 +22,10 @@ public record OnboardUserDto (
         String confirmPassword,
 
         @NotNull(message = "College building is required")
-        String collegeBuildingId,
+        int collegeBuildingId,
 
         @NotNull(message = "Department is required")
-        String departmentId,
+        int departmentId,
 
         @NotNull(message = "Invite Verification is required")
         Boolean inviteVerified

--- a/src/main/java/com/henry/universitycourseschedular/models/_dto/OnboardUserDto.java
+++ b/src/main/java/com/henry/universitycourseschedular/models/_dto/OnboardUserDto.java
@@ -22,10 +22,10 @@ public record OnboardUserDto (
         String confirmPassword,
 
         @NotNull(message = "College building is required")
-        int collegeBuildingId,
+        Long collegeBuildingId,
 
         @NotNull(message = "Department is required")
-        int departmentId,
+        Long departmentId,
 
         @NotNull(message = "Invite Verification is required")
         Boolean inviteVerified

--- a/src/main/java/com/henry/universitycourseschedular/models/_dto/VenueDTO.java
+++ b/src/main/java/com/henry/universitycourseschedular/models/_dto/VenueDTO.java
@@ -1,0 +1,18 @@
+package com.henry.universitycourseschedular.models._dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class VenueDTO {
+    private String name;              // e.g., "LT 1"
+    private int capacity;             // e.g., 120
+    @Builder.Default
+    private boolean available = true;
+    private String collegeCode;       // Used to fetch the associated CollegeBuilding
+}

--- a/src/main/java/com/henry/universitycourseschedular/models/_dto/VenueDTO.java
+++ b/src/main/java/com/henry/universitycourseschedular/models/_dto/VenueDTO.java
@@ -12,7 +12,6 @@ import lombok.Data;
 public class VenueDTO {
     private String name;              // e.g., "LT 1"
     private int capacity;             // e.g., 120
-    @Builder.Default
-    private boolean available = true;
+    private boolean available;
     private String collegeCode;       // Used to fetch the associated CollegeBuilding
 }

--- a/src/main/java/com/henry/universitycourseschedular/models/core/Venue.java
+++ b/src/main/java/com/henry/universitycourseschedular/models/core/Venue.java
@@ -18,6 +18,9 @@ public class Venue {
 
     private int capacity;
 
+    @Builder.Default
+    private boolean available = true;
+
     @ManyToOne(fetch = FetchType.LAZY)
     private CollegeBuilding collegeBuilding;
 }

--- a/src/main/java/com/henry/universitycourseschedular/models/schedule/TimeSlot.java
+++ b/src/main/java/com/henry/universitycourseschedular/models/schedule/TimeSlot.java
@@ -1,11 +1,9 @@
 package com.henry.universitycourseschedular.models.schedule;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.DayOfWeek;
 import java.time.LocalTime;
 
 @Entity
@@ -19,11 +17,14 @@ public class TimeSlot {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private LocalTime start;
-    private LocalTime end;
+    @Enumerated(EnumType.STRING)
+    private DayOfWeek dayOfWeek;
+
+    private LocalTime startTime;
+    private LocalTime endTime;
 
     @Override
     public String toString() {
-        return start + " - " + end;
+        return startTime + " - " + endTime;
     }
 }

--- a/src/main/java/com/henry/universitycourseschedular/repositories/CollegeBuildingRepository.java
+++ b/src/main/java/com/henry/universitycourseschedular/repositories/CollegeBuildingRepository.java
@@ -4,6 +4,9 @@ import com.henry.universitycourseschedular.models.core.CollegeBuilding;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface CollegeBuildingRepository extends JpaRepository<CollegeBuilding, Long> {
+    Optional<CollegeBuilding> findByCode(String code);
 }

--- a/src/main/java/com/henry/universitycourseschedular/repositories/DepartmentRepository.java
+++ b/src/main/java/com/henry/universitycourseschedular/repositories/DepartmentRepository.java
@@ -3,5 +3,8 @@ package com.henry.universitycourseschedular.repositories;
 import com.henry.universitycourseschedular.models.core.Department;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface DepartmentRepository extends JpaRepository<Department, Long> {
+    Optional<Department> findByCode(String code);
 }


### PR DESCRIPTION
### PR Description:

This PR finalizes the seeding for all core models including departments, programs, lecturers, and venues to provide a solid initial dataset for the application.

**Key updates include:**

* Full implementation of seeders for departments, programs, lecturers, and venues.
* Bugfix in `AuthenticationService` to allow `null` values for `department` and `collegeBuilding` specifically for DAPU users.
* Corrected field order (name/code) in Department and Venue seeders to align with domain model requirements.
* General cleanup and consistency improvements in seeding logic to ensure data integrity and prevent future bugs.