### PR TITLE
feat(seed): add GeneralBodySeeder for university-wide course bodies

### DIFF
--- a/src/main/java/com/henry/universitycourseschedular/data/CollegeBuildingSeeder.java
+++ b/src/main/java/com/henry/universitycourseschedular/data/CollegeBuildingSeeder.java
@@ -3,11 +3,12 @@ package com.henry.universitycourseschedular.data;
 import com.henry.universitycourseschedular.models.core.CollegeBuilding;
 import com.henry.universitycourseschedular.repositories.CollegeBuildingRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-@Component
+@Component @Slf4j
 @RequiredArgsConstructor
 public class CollegeBuildingSeeder {
 
@@ -25,5 +26,7 @@ public class CollegeBuildingSeeder {
                 CollegeBuilding.builder().code("CIVIL").name("College of Civil Engineering").build(),
                 CollegeBuilding.builder().code("EIE").name("College of Electrical Engineering").build()
         ));
+
+        log.info("✅ Seeded College Buildings");
     }
 }

--- a/src/main/java/com/henry/universitycourseschedular/data/DepartmentSeeder.java
+++ b/src/main/java/com/henry/universitycourseschedular/data/DepartmentSeeder.java
@@ -6,12 +6,13 @@ import com.henry.universitycourseschedular.models.core.Department;
 import com.henry.universitycourseschedular.repositories.CollegeBuildingRepository;
 import com.henry.universitycourseschedular.repositories.DepartmentRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
 
-@Component
+@Component @Slf4j
 @RequiredArgsConstructor
 public class DepartmentSeeder {
 
@@ -72,6 +73,8 @@ public class DepartmentSeeder {
         ));
 
         departmentRepository.saveAll(all);
+
+        log.info("✅ Seeded Departments across College Buildings.");
     }
 
     private CollegeBuilding getBuilding(String code) {

--- a/src/main/java/com/henry/universitycourseschedular/data/GeneralBodySeeder.java
+++ b/src/main/java/com/henry/universitycourseschedular/data/GeneralBodySeeder.java
@@ -1,0 +1,26 @@
+package com.henry.universitycourseschedular.data;
+
+import com.henry.universitycourseschedular.models.core.GeneralBody;
+import com.henry.universitycourseschedular.repositories.GeneralBodyRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component @Slf4j
+@RequiredArgsConstructor
+public class GeneralBodySeeder {
+    private final GeneralBodyRepository generalBodyRepository;
+
+    public void seed() {
+        if (generalBodyRepository.count() == 0) {
+            List<GeneralBody> bodies = List.of(
+                    new GeneralBody(null, "CEDS", "Center for Entrepreneurial Development Studies"),
+                    new GeneralBody(null, "ALDC", "African Leadership Development Centre")
+            );
+            generalBodyRepository.saveAll(bodies);
+            log.info("✅ Seeded General Bodies");
+        }
+    }
+}

--- a/src/main/java/com/henry/universitycourseschedular/data/ProgramSeeder.java
+++ b/src/main/java/com/henry/universitycourseschedular/data/ProgramSeeder.java
@@ -6,12 +6,13 @@ import com.henry.universitycourseschedular.models.core.Program;
 import com.henry.universitycourseschedular.repositories.DepartmentRepository;
 import com.henry.universitycourseschedular.repositories.ProgramRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.function.Function;
 
-@Component
+@Component @Slf4j
 @RequiredArgsConstructor
 public class ProgramSeeder {
 
@@ -70,5 +71,7 @@ public class ProgramSeeder {
                 Program.builder().code("PETE").name("Petroleum Engineering").department(getDept.apply("PETE")).build(),
                 Program.builder().code("CHEMENG").name("Chemical Engineering").department(getDept.apply("CHEMENG")).build()
         ));
+
+        log.info("✅ Seeded Programs across various departments");
     }
 }

--- a/src/main/java/com/henry/universitycourseschedular/data/TimeSlotSeeder.java
+++ b/src/main/java/com/henry/universitycourseschedular/data/TimeSlotSeeder.java
@@ -4,6 +4,7 @@ import com.henry.universitycourseschedular.models.schedule.TimeSlot;
 import com.henry.universitycourseschedular.repositories.TimeSlotRepository;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.time.DayOfWeek;
@@ -11,7 +12,7 @@ import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 
-@Component
+@Component @Slf4j
 @RequiredArgsConstructor
 public class TimeSlotSeeder {
 
@@ -51,5 +52,7 @@ public class TimeSlotSeeder {
             }
         }
         timeSlotRepository.saveAll(timeSlots);
+
+        log.info("✅ Seeded TimeSlot.");
     }
 }

--- a/src/main/java/com/henry/universitycourseschedular/data/VenueSeeder.java
+++ b/src/main/java/com/henry/universitycourseschedular/data/VenueSeeder.java
@@ -8,12 +8,13 @@ import com.henry.universitycourseschedular.models.core.Venue;
 import com.henry.universitycourseschedular.repositories.CollegeBuildingRepository;
 import com.henry.universitycourseschedular.repositories.VenueRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Objects;
 
-@Component
+@Component @Slf4j
 @RequiredArgsConstructor
 public class VenueSeeder {
 
@@ -90,5 +91,7 @@ public class VenueSeeder {
                 .toList();
 
         venueRepository.saveAll(venues);
+
+        log.info("✅ Seeded Venues across different college buildings");
     }
 }

--- a/src/main/java/com/henry/universitycourseschedular/data/_SeederRunner.java
+++ b/src/main/java/com/henry/universitycourseschedular/data/_SeederRunner.java
@@ -13,6 +13,7 @@ public class _SeederRunner {
     private final ProgramSeeder programSeeder;
     private final VenueSeeder venueSeeder;
     private final TimeSlotSeeder timeSlotSeeder;
+    private final GeneralBodySeeder generalBodySeeder;
 
     @PostConstruct
     public void run() {
@@ -21,6 +22,8 @@ public class _SeederRunner {
         programSeeder.seed();
         venueSeeder.seed();
         timeSlotSeeder.seed();
+        generalBodySeeder.seed();
+
     }
 
 }


### PR DESCRIPTION
### 🧩 Description:

This PR introduces a data seeder for the `GeneralBody` entity, used to represent general course-managing units such as:

* CEDS (Center for Entrepreneurial Development Studies)
* ALDC (African Leadership Development Centre)