### PR TITLE
Feature: Add GeneralBody Support with CRUD API, DTO, Mapper, and DefaultApiResponse Integration

### DIFF
--- a/src/main/java/com/henry/universitycourseschedular/controllers/GeneralBodyController.java
+++ b/src/main/java/com/henry/universitycourseschedular/controllers/GeneralBodyController.java
@@ -1,0 +1,43 @@
+package com.henry.universitycourseschedular.controllers;
+
+import com.henry.universitycourseschedular.models._dto.DefaultApiResponse;
+import com.henry.universitycourseschedular.models._dto.GeneralBodyDto;
+import com.henry.universitycourseschedular.models.core.GeneralBody;
+import com.henry.universitycourseschedular.services.core.GeneralBodyService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/general-bodies")
+@RequiredArgsConstructor
+public class GeneralBodyController {
+
+    private final GeneralBodyService generalBodyService;
+
+    @PostMapping
+    public DefaultApiResponse<GeneralBody> create(@RequestBody GeneralBodyDto dto) {
+        return generalBodyService.createGeneralBody(dto);
+    }
+
+    @PutMapping("/{id}")
+    public DefaultApiResponse<GeneralBody> update(@PathVariable Long id, @RequestBody GeneralBodyDto dto) {
+        return generalBodyService.updateGeneralBody(id, dto);
+    }
+
+    @DeleteMapping("/{id}")
+    public DefaultApiResponse<?> delete(@PathVariable Long id) {
+        return generalBodyService.deleteGeneralBody(id);
+    }
+
+    @GetMapping
+    public DefaultApiResponse<List<GeneralBody>> getAll() {
+        return generalBodyService.getAllGeneralBodies();
+    }
+
+    @GetMapping("/{id}")
+    public DefaultApiResponse<GeneralBody> getById(@PathVariable Long id) {
+        return generalBodyService.getGeneralBodyById(id);
+    }
+}

--- a/src/main/java/com/henry/universitycourseschedular/mapper/GeneralBodyMapper.java
+++ b/src/main/java/com/henry/universitycourseschedular/mapper/GeneralBodyMapper.java
@@ -1,0 +1,15 @@
+package com.henry.universitycourseschedular.mapper;
+
+import com.henry.universitycourseschedular.models._dto.GeneralBodyDto;
+import com.henry.universitycourseschedular.models.core.GeneralBody;
+
+public class GeneralBodyMapper {
+    public static GeneralBody fromDto(GeneralBodyDto dto) {
+        return new GeneralBody(null, dto.name(), dto.code());
+    }
+
+    public static void updateFromDto(GeneralBody existing, GeneralBodyDto dto) {
+        existing.setName(dto.name());
+        existing.setCode(dto.code());
+    }
+}

--- a/src/main/java/com/henry/universitycourseschedular/models/_dto/GeneralBodyDto.java
+++ b/src/main/java/com/henry/universitycourseschedular/models/_dto/GeneralBodyDto.java
@@ -1,0 +1,6 @@
+package com.henry.universitycourseschedular.models._dto;
+
+public record GeneralBodyDto(
+        String name,
+        String code
+) {}

--- a/src/main/java/com/henry/universitycourseschedular/services/core/GeneralBodyService.java
+++ b/src/main/java/com/henry/universitycourseschedular/services/core/GeneralBodyService.java
@@ -1,0 +1,15 @@
+package com.henry.universitycourseschedular.services.core;
+
+import com.henry.universitycourseschedular.models._dto.DefaultApiResponse;
+import com.henry.universitycourseschedular.models._dto.GeneralBodyDto;
+import com.henry.universitycourseschedular.models.core.GeneralBody;
+
+import java.util.List;
+
+public interface GeneralBodyService {
+    DefaultApiResponse<GeneralBody> createGeneralBody(GeneralBodyDto dto);
+    DefaultApiResponse<GeneralBody> updateGeneralBody(Long id, GeneralBodyDto dto);
+    DefaultApiResponse<?> deleteGeneralBody(Long id);
+    DefaultApiResponse<List<GeneralBody>> getAllGeneralBodies();
+    DefaultApiResponse<GeneralBody> getGeneralBodyById(Long id);
+}

--- a/src/main/java/com/henry/universitycourseschedular/services/core/GeneralBodyServiceImpl.java
+++ b/src/main/java/com/henry/universitycourseschedular/services/core/GeneralBodyServiceImpl.java
@@ -1,0 +1,67 @@
+package com.henry.universitycourseschedular.services.core;
+
+import com.henry.universitycourseschedular.constants.StatusCodes;
+import com.henry.universitycourseschedular.exceptions.ResourceNotFoundException;
+import com.henry.universitycourseschedular.mapper.GeneralBodyMapper;
+import com.henry.universitycourseschedular.models._dto.DefaultApiResponse;
+import com.henry.universitycourseschedular.models._dto.GeneralBodyDto;
+import com.henry.universitycourseschedular.models.core.GeneralBody;
+import com.henry.universitycourseschedular.repositories.GeneralBodyRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import static com.henry.universitycourseschedular.utils.ApiResponseUtil.buildErrorResponse;
+import static com.henry.universitycourseschedular.utils.ApiResponseUtil.buildSuccessResponse;
+
+@Service @RequiredArgsConstructor @Slf4j
+public class GeneralBodyServiceImpl implements GeneralBodyService {
+
+    private final GeneralBodyRepository generalBodyRepo;
+
+    @Override
+    public DefaultApiResponse<GeneralBody> createGeneralBody(GeneralBodyDto dto) {
+        try {
+            GeneralBody body = GeneralBodyMapper.fromDto(dto);
+            generalBodyRepo.save(body);
+            return buildSuccessResponse("General body created", StatusCodes.ACTION_COMPLETED, body);
+        } catch (Exception e) {
+            log.error("Unable to create general body", e);
+            return buildErrorResponse("Error creating general body");
+        }
+    }
+
+    @Override
+    public DefaultApiResponse<GeneralBody> updateGeneralBody(Long id, GeneralBodyDto dto) {
+        GeneralBody existing = generalBodyRepo.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("General body not found"));
+
+        GeneralBodyMapper.updateFromDto(existing, dto);
+        generalBodyRepo.save(existing);
+
+        return buildSuccessResponse("General body updated", StatusCodes.ACTION_COMPLETED, existing);
+    }
+
+    @Override
+    public DefaultApiResponse<?> deleteGeneralBody(Long id) {
+        if (!generalBodyRepo.existsById(id)) {
+            return buildErrorResponse("General body not found");
+        }
+        generalBodyRepo.deleteById(id);
+        return buildSuccessResponse("General body deleted");
+    }
+
+    @Override
+    public DefaultApiResponse<List<GeneralBody>> getAllGeneralBodies() {
+        return buildSuccessResponse("All general bodies", StatusCodes.ACTION_COMPLETED, generalBodyRepo.findAll());
+    }
+
+    @Override
+    public DefaultApiResponse<GeneralBody> getGeneralBodyById(Long id) {
+        GeneralBody body = generalBodyRepo.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("General body not found"));
+        return buildSuccessResponse("General body found", StatusCodes.ACTION_COMPLETED, body);
+    }
+}


### PR DESCRIPTION
### 📝 **Pull Request Description**

This PR introduces full support for managing `GeneralBody` entities, used to handle general university courses (e.g., TMC, EDS). The following components were added:

* ✅ `GeneralBodyDto` for data transfer
* ✅ `GeneralBodyMapper` for conversion logic
* ✅ `GeneralBodyService` and `ServiceImpl` using `DefaultApiResponse` pattern
* ✅ `GeneralBodyController` with clean, RESTful endpoints
* ✅ Proper error handling and centralized API responses
